### PR TITLE
Replace some Actions with shell scripts

### DIFF
--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -51,12 +51,8 @@ jobs:
           tags: ${{ inputs.tags }}
 
       - name: Log in to Container Registry
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
-        if: ${{ github.event_name != 'pull_request' }}
-        with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ${{ inputs.registry }}/${{ inputs.namespace }}
+        shell: bash
+        run: ./log-in-to-registry.sh "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}" "${{ inputs.registry }}/${{ inputs.namespace }}"
 
       - name: Push to Container Registry
         uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -37,11 +37,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install cosign
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
-        with:
-          cosign-release: 'v2.4.1'
+      - name: Install Cosign
+        shell: bash
+        run: ./install-cosign.sh "${{ runner.arch }}" "$RUNNER_TEMP"
 
       - name: Build image
         id: build

--- a/install-cosign.sh
+++ b/install-cosign.sh
@@ -4,6 +4,7 @@
 
 runner_arch="$1"
 workdir="$2" # Should be $RUNNER_TEMP
+toolsdir="${HOME}/tools"
 
 tag="v2.4.3"
 commit="6a7abbf3ae7eb6949883a80c8f6007cc065d2dfb"
@@ -21,8 +22,9 @@ log_fatal_die() {
 set -e
 trap "popd >/dev/null" EXIT
 pushd "${workdir}" > /dev/null
-mkdir -p "${HOME}/tools"
-echo "${HOME}/tools" >> $GITHUB_PATH
+mkdir -p "${toolsdir}"
+export PATH="$PATH:${toolsdir}" # makes it available in this step
+echo "${toolsdir}" >> $GITHUB_PATH # makes it availabe in later steps
 
 # Clone the repo
 git clone -b "${tag}" https://github.com/sigstore/cosign.git

--- a/install-cosign.sh
+++ b/install-cosign.sh
@@ -39,5 +39,6 @@ fi
 # Build and install cosign
 go install ./cmd/cosign
 cp "$(go env GOPATH)/bin/cosign" "${HOME}/tools/cosign"
+log_info "Installed cosign $(cosign version --json | jq -r '.gitVersion')"
 
 exit 0

--- a/install-cosign.sh
+++ b/install-cosign.sh
@@ -41,6 +41,6 @@ fi
 # Build and install cosign
 go install ./cmd/cosign
 cp "$(go env GOPATH)/bin/cosign" "${HOME}/tools/cosign"
-log_info "Installed cosign $(cosign version --json | jq -r '.gitVersion')"
+log_info "Installed cosign from commit $(cosign version --json | jq -r '.gitCommit')"
 
 exit 0

--- a/install-cosign.sh
+++ b/install-cosign.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Cosign install script
+
+runner_arch="$1"
+workdir="$2" # Should be $RUNNER_TEMP
+
+tag="v2.4.3"
+commit="6a7abbf3ae7eb6949883a80c8f6007cc065d2dfb"
+
+log_info() {
+    1>&2 echo "[INFO]: $*"
+}
+
+log_fatal_die() {
+    1>&2 echo "[FATAL]: $*"
+    exit 1
+}
+
+# Setup
+set -e
+trap "popd >/dev/null" EXIT
+pushd "${workdir}" > /dev/null
+mkdir -p "${HOME}/tools"
+echo "${HOME}/tools" >> $GITHUB_PATH
+
+# Clone the repo
+git clone -b "${tag}" https://github.com/sigstore/cosign.git
+cd cosign
+
+# Verify the tag and commit
+current_commit=$(git rev-parse HEAD)
+if [ "${current_commit}" = "${commit}" ]; then
+    log_info "Commit hash verified: ${current_commit}"
+else
+    log_fatal_die "Commmit hash mismatch!"
+fi
+
+# Build and install cosign
+go install ./cmd/cosign
+cp "$(go env GOPATH)/bin/cosign" "${HOME}/tools/cosign"
+
+exit 0

--- a/log-in-to-registry.sh
+++ b/log-in-to-registry.sh
@@ -10,16 +10,54 @@ log_info() {
     1>&2 echo "[INFO]: $*"
 }
 
+log_fatal_die() {
+    1>&2 echo "[FATAL]: $*"
+    exit 1
+}
+
+# Required parameters
+if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
+  log_fatal_die "Usage: $0 <username> <password> <registry>"
+fi
+
 # Setup
 set -e
 log_info "Using $(podman -v)"
 
+# Determine default podman auth file location
+if [ -n "$XDG_RUNTIME_DIR" ]; then
+  auth_file_dir="$XDG_RUNTIME_DIR"
+else
+  auth_file_dir="/tmp/podman-run-$(id -u)"
+fi
+podman_auth_file="${auth_file_dir}/containers/auth.json"
+
+# Set environment variable for buildah
+export REGISTRY_AUTH_FILE="$podman_auth_file"
+echo "Exporting REGISTRY_AUTH_FILE=${podman_auth_file}"
+
 podman login \
     --username "$username" \
     --password "$password" \
-    --compat-auth-file "${HOME}/.docker/config.json" \
+    --verbose \
     "$registry"
 
-log_info "Successfully logged in to $registry as $username"
+# Make sure Docker config directory exists
+docker_config_dir="${HOME}/.docker"
+mkdir -p "$docker_config_dir"
+docker_config_path="${docker_config_dir}/config.json"
+
+# Create Docker config if it doesn't exist
+if [ ! -f "$docker_config_path" ]; then
+  echo '{"auths":{}}' > "$docker_config_path"
+fi
+
+# Read Podman auth for this registry and add to Docker config
+log_info "Writing registry credentials to ${docker_config_path}"
+podman_auth=$(cat "$podman_auth_file" | jq -r ".auths[\"$registry\"]")
+cat "$docker_config_path" | jq ".auths[\"$registry\"] = $podman_auth" > "${docker_config_path}.new"
+mv "${docker_config_path}.new" "$docker_config_path"
+
+log_info "Successfully logged in to ${registry} as ${username}"
 
 exit 0

--- a/log-in-to-registry.sh
+++ b/log-in-to-registry.sh
@@ -17,6 +17,7 @@ log_info "Using $(podman -v)"
 podman login \
     --username "$username" \
     --password "$password" \
+    --compat-auth-file "${HOME}/.docker/config.json" \
     "$registry"
 
 log_info "Successfully logged in to $registry as $username"

--- a/log-in-to-registry.sh
+++ b/log-in-to-registry.sh
@@ -19,4 +19,6 @@ podman login \
     --password "$password" \
     "$registry"
 
+log_info "Successfully logged in to $registry as $username"
+
 exit 0

--- a/log-in-to-registry.sh
+++ b/log-in-to-registry.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Log in to Container Registry
+
+username="$1"
+password="$2"
+registry="$3"
+
+log_info() {
+    1>&2 echo "[INFO]: $*"
+}
+
+# Setup
+set -e
+log_info "Using $(podman -v)"
+
+podman login \
+    --username "$username" \
+    --password "$password" \
+    "$registry"
+
+exit 0

--- a/packages.json
+++ b/packages.json
@@ -5,6 +5,10 @@
         "_comment": "Visual Studio Code needs to be on the host because it's an Electron app"
       },
       {
+        "name": "docker",
+        "_comment": "Installs containerd, moby-engine, and runc"
+      },
+      {
         "name": "gcc",
         "_comment": "Required for Homebrew"
       },
@@ -39,10 +43,6 @@
       {
         "name": "openssh-askpass",
         "_comment": "Needed to prompt for PIN for TPM-bound SSH keys"
-      },
-      {
-        "name": "docker",
-        "_comment": "Installs containerd, moby-engine, and runc"
       },
       {
         "name": "powertop",


### PR DESCRIPTION
Closes #24 

In an effort to reduce the total number of third-party dependencies in my GitHub Actions workflows, this replaces a couple easy ones to start.

The Cosign one is pretty straightforward.

I decided to build and install it from source because then it's easy to verify the source? It seemed to dodge the problem I saw with `xz` that the artifacts were different sometimes. 

The Podman Login one was harder. 

That one, the `--compat-auth-file "${HOME}/.docker/config.json" ` option doesn't work. It claims 
```
Error: Credentials cannot be recorded in Docker-compatible format with namespaced key "ghcr.io/samhclark"
```

So I pasted the whole `action.yaml` from podman-login into Claude and asked for a translation. This was adapted from that. 